### PR TITLE
Fix closing quotes typo in poetry config file

### DIFF
--- a/movie-recommendation-api/pyproject.toml
+++ b/movie-recommendation-api/pyproject.toml
@@ -21,4 +21,4 @@ Flask-SQLAlchemy = "^2.4.4"
 
 [build-system]
 requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
I found and fixed a minor typo in the poetry file - missing closing quotes that makes the problem upon dependency installation. :smile:  